### PR TITLE
chore: modernize Terraform and provider versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.1.0 - 2026-03-26
+
+Changed
+- Bumped minimum Terraform version from `>= 1.3` to `>= 1.9` (breaking for callers running Terraform < 1.9)
+- Bumped azurerm provider constraint from `~> 3.22` to `~> 3.116`
+
 # v1.0.0 - <date>
 
 Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/POps-Rox/tf-overlays-template/pulls)
 [![Maintained](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/POps-Rox/tf-overlays-template/graphs/commit-activity)
-[![Terraform](https://img.shields.io/badge/Terraform-%3E%3D1.5-623CE4.svg?logo=terraform)](https://www.terraform.io)
+[![Terraform](https://img.shields.io/badge/Terraform-%3E%3D1.9-623CE4.svg?logo=terraform)](https://www.terraform.io)
 <!-- BADGES:END -->
 
 # Azure Template Overlay

--- a/examples/Commerical/example_new_rg/versions.tf
+++ b/examples/Commerical/example_new_rg/versions.tf
@@ -1,6 +1,20 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
+    }
+    azurenoopsutils = {
+      source  = "azurenoops/azurenoopsutils"
+      version = "~> 1.0.4"
+    }
+  }
+}
+
 # Azurerm provider configuration
 provider "azurerm" {
   features {}

--- a/examples/Government/example_new_rg/versions.tf
+++ b/examples/Government/example_new_rg/versions.tf
@@ -1,6 +1,20 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
+    }
+    azurenoopsutils = {
+      source  = "azurenoops/azurenoopsutils"
+      version = "~> 1.0.4"
+    }
+  }
+}
+
 # Azurerm provider configuration
 provider "azurerm" {
   features {}

--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,11 @@
 # Licensed under the MIT License.
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.22"
+      version = "~> 3.116"
     }
     azurenoopsutils = {
       source  = "azurenoops/azurenoopsutils"


### PR DESCRIPTION
## Summary
Modernize version constraints to current standards.
### Changes
- Terraform `>= 1.3` → `>= 1.9`
- azurerm `~> 3.x` → `~> 3.116`
- azurenoopsutils → `~> 1.0.4`
- Updated examples and documentation
Closes #4